### PR TITLE
feat: Integrate ChatGPT using Spring AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# Demo AI Project - ChatGPT Integration
+
+This project is a Spring Boot application that demonstrates how to integrate with OpenAI's ChatGPT using the Spring AI library.
+
+## Prerequisites
+
+- Java 17 or later
+- Maven
+- An active OpenAI API Key
+
+## Setup
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository-url>
+    cd demo-ai
+    ```
+
+2.  **Configure OpenAI API Key:**
+    You need to provide your OpenAI API key to the application. You can do this in one of two ways:
+
+    *   **Option A: Environment Variable (Recommended)**
+        Set the `SPRING_AI_OPENAI_API_KEY` environment variable:
+        ```bash
+        export SPRING_AI_OPENAI_API_KEY="your_openai_api_key_here"
+        ```
+        On Windows, use `set SPRING_AI_OPENAI_API_KEY="your_openai_api_key_here"` in Command Prompt or `$env:SPRING_AI_OPENAI_API_KEY="your_openai_api_key_here"` in PowerShell.
+
+    *   **Option B: `application.properties` file**
+        Open the `src/main/resources/application.properties` file and replace `YOUR_API_KEY` with your actual OpenAI API key:
+        ```properties
+        spring.ai.openai.api-key=your_openai_api_key_here
+        ```
+        **Note:** Be careful not to commit your API key to version control if you use this method in a shared repository.
+
+3.  **Choose a Model (Optional):**
+    The application is configured to use `gpt-3.5-turbo` by default. You can change this in `src/main/resources/application.properties`:
+    ```properties
+    spring.ai.openai.chat.options.model=gpt-4 # Or any other model you have access to
+    ```
+
+## Running the Application
+
+1.  **Build the project:**
+    ```bash
+    ./mvnw clean package
+    ```
+    (On Windows, use `mvnw.cmd clean package`)
+
+2.  **Run the Spring Boot application:**
+    ```bash
+    java -jar target/demo-ai-0.0.1-SNAPSHOT.war
+    ```
+    Alternatively, you can run directly using the Maven Spring Boot plugin:
+    ```bash
+    ./mvnw spring-boot:run
+    ```
+
+The application will start on the default port (usually 8080).
+
+## Using the API
+
+You can interact with the ChatGPT integration through a POST request to the `/api/v1/chat` endpoint.
+
+**Endpoint:** `POST /api/v1/chat`
+
+**Request Body (JSON):**
+```json
+{
+  "prompt": "What is the capital of France?"
+}
+```
+
+**Example using Postman:**
+
+1.  Open Postman.
+2.  Create a new request:
+    *   Set the method to `POST`.
+    *   Set the URL to `http://localhost:8080/api/v1/chat`.
+3.  Go to the "Body" tab:
+    *   Select "raw".
+    *   Choose "JSON" from the dropdown.
+    *   Paste the request body:
+        ```json
+        {
+          "prompt": "Tell me a joke about programming."
+        }
+        ```
+4.  Click "Send".
+
+**Example Response (Success - 200 OK):**
+```json
+{
+  "response": "Why was the JavaScript developer sad? Because he didn't Node how to Express himself!"
+}
+```
+
+**Example Response (Error - 400 Bad Request if prompt is missing):**
+```json
+{
+  "error": "Prompt cannot be empty."
+}
+```
+
+**Example Response (Error - 500 Internal Server Error if API key is invalid or other server issues):**
+```json
+{
+  "error": "Error: Could not get response from AI service."
+}
+```
+
+This indicates an issue with the OpenAI API call, often due to an invalid or missing API key, or network problems. Check the application logs for more details.

--- a/src/main/java/com/ai/example/demoai/controller/ChatGPTController.java
+++ b/src/main/java/com/ai/example/demoai/controller/ChatGPTController.java
@@ -1,0 +1,56 @@
+package com.ai.example.demoai.controller;
+
+import com.ai.example.demoai.service.ChatGPTService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/chat")
+public class ChatGPTController {
+
+    private final ChatGPTService chatGPTService;
+
+    public ChatGPTController(ChatGPTService chatGPTService) {
+        this.chatGPTService = chatGPTService;
+    }
+
+    // Inner class for request payload
+    public static class ChatRequest {
+        private String prompt;
+
+        public String getPrompt() {
+            return prompt;
+        }
+
+        public void setPrompt(String prompt) {
+            this.prompt = prompt;
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<Map<String, String>> chat(@RequestBody ChatRequest chatRequest) {
+        if (chatRequest == null || chatRequest.getPrompt() == null || chatRequest.getPrompt().trim().isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Prompt cannot be empty."));
+        }
+
+        try {
+            String response = chatGPTService.getChatGPTResponse(chatRequest.getPrompt());
+            if (response.startsWith("Error:")) {
+                 // Let's assume service returns "Error:..." for service-level errors
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", response));
+            }
+            return ResponseEntity.ok(Map.of("response", response));
+        } catch (Exception e) {
+            // Log the exception server-side
+            System.err.println("Unexpected error in ChatGPTController: " + e.getMessage());
+            // Return a generic error to the client
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "An unexpected error occurred."));
+        }
+    }
+}

--- a/src/main/java/com/ai/example/demoai/service/ChatGPTService.java
+++ b/src/main/java/com/ai/example/demoai/service/ChatGPTService.java
@@ -1,0 +1,29 @@
+package com.ai.example.demoai.service;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChatGPTService {
+
+    private final ChatClient chatClient;
+
+    public ChatGPTService(ChatClient.Builder chatClientBuilder) {
+        this.chatClient = chatClientBuilder.build();
+    }
+
+    public String getChatGPTResponse(String userPrompt) {
+        try {
+            Prompt prompt = new Prompt(userPrompt);
+            ChatResponse response = chatClient.prompt(prompt).call().chatResponse();
+            return response.getResult().getOutput().getContent();
+        } catch (Exception e) {
+            // Basic error logging, can be enhanced
+            System.err.println("Error calling OpenAI API: " + e.getMessage());
+            // In a real application, throw a custom exception or handle more gracefully
+            return "Error: Could not get response from AI service.";
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=demo-ai
+
+# OpenAI API Configuration
+# Replace YOUR_API_KEY with your actual OpenAI API key,
+# or set the SPRING_AI_OPENAI_API_KEY environment variable.
+spring.ai.openai.api-key=YOUR_API_KEY
+spring.ai.openai.chat.options.model=gpt-3.5-turbo
+# You can also specify other options, for example:
+# spring.ai.openai.chat.options.temperature=0.7


### PR DESCRIPTION
- Added ChatGPTService to interact with OpenAI API via Spring AI's ChatClient.
- Added ChatGPTController with a POST endpoint /api/v1/chat to receive prompts and return AI responses.
- Configured API key access through application.properties, supporting environment variables.
- Created README.md with setup, run, and API usage instructions.